### PR TITLE
Fix usage of `sed` in `template-cleanup.sh`

### DIFF
--- a/.github/template-cleanup.sh
+++ b/.github/template-cleanup.sh
@@ -8,5 +8,5 @@ rm README.md
 mv .github/template-cleanup/README.md README.md
 rm .github/workflows/cleanup.yml
 rm .github/template-cleanup.sh
-sed -i '' -e "s~%REPOSITORY%~$GITHUB_REPOSITORY~g" README.md
-sed -i '' -e "s~%NAME%~${REPOARR[1]}~g" README.md
+sed -i -e "s~%REPOSITORY%~$GITHUB_REPOSITORY~g" README.md
+sed -i -e "s~%NAME%~${REPOARR[1]}~g" README.md


### PR DESCRIPTION
Otherwise, users will see this CI error: https://github.com/UNIDY2002/repro-rn-73-android/actions/runs/6445982976/job/17500610742
```
sed: can't read : No such file or directory
sed: can't read : No such file or directory
```