### PR TITLE
Bump node to 18 & Java to 17

### DIFF
--- a/.github/workflows/auto-updater.yml
+++ b/.github/workflows/auto-updater.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Check React Native Version
         id: yarnoutdated

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Yarn Install
         run: yarn install

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Node 18 is now a requirement. Updating it in the reproducer template