### PR TITLE
Fix iOS build in `pre-merge.yml`

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -61,5 +61,5 @@ jobs:
         working-directory: ReproducerApp/ios
 
       - name: Yarn Build iOS
-        run: yarn react-native run-ios
+        run: yarn react-native build-ios
         working-directory: ReproducerApp


### PR DESCRIPTION
## Summary
iOS build action in `pre-merge.yml` is failing when we use `yarn react-native run-ios` with error:
`error Cannot start server in new window because no terminal app was specified`
![ios-build-action-ss](https://github.com/react-native-community/reproducer-react-native/assets/83216158/5b30f621-12e3-42f8-a35e-c576fb0f6c84)

To fix this I used `yarn react-native build-ios` (it's already used in android build). 

## Test Plan
I already made this change in [my repo](https://github.com/KrzysztofMoch/react-native-intertrop-repro) and it's working 
