### PR TITLE
test(ci, android): add step to clear space for source builds

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -12,6 +12,17 @@ jobs:
   test-android:
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: insightsengineering/disk-space-reclaimer@v1
+        with:
+          tools-cache: false
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+
       - name: Checkout Repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION

@cortinico here's a little side PR from the headless-JS thing - Reproducer CI build fails if building from source but I had some experience with similar so was aware of an easy github action to fix it. Maybe of interest?

If you want to test a reproducer using react-native built from source you need a lot more space in CI than the runner has by default

The addition of this action, with these settings, clears enough space to work

---
Examples where it failed the first time I built from source, then again with just a little space cleared, then it worked with more space cleared:

https://github.com/mikehardy/old-arch-android-receiver-boot-crash/actions
